### PR TITLE
Better BrowserView structure

### DIFF
--- a/src/collective/smsauthenticator/browser/configure.zcml
+++ b/src/collective/smsauthenticator/browser/configure.zcml
@@ -90,8 +90,8 @@
     <browser:page
         name="sms-authenticator-show-unique-user-ips"
         for="Products.CMFPlone.interfaces.IPloneSiteRoot"
-        class=".list_user_ips.ListUserIPs"
-        attribute="unique"
+        class=".list_user_ips.ListUniqueUserIPs"
+        template="templates/show_unique_user_ips.pt"
         permission="cmf.ManagePortal"
         />
 
@@ -99,8 +99,8 @@
     <browser:page
         name="sms-authenticator-show-all-user-ips"
         for="Products.CMFPlone.interfaces.IPloneSiteRoot"
-        class=".list_user_ips.ListUserIPs"
-        attribute="all"
+        class=".list_user_ips.ListAllUserIPs"
+        template="templates/show_all_user_ips.pt"
         permission="cmf.ManagePortal"
         />
 

--- a/src/collective/smsauthenticator/browser/list_user_ips.py
+++ b/src/collective/smsauthenticator/browser/list_user_ips.py
@@ -12,11 +12,8 @@ _ = MessageFactory('collective.smsauthenticator')
 
 class ListUserIPs(BrowserView):
     """
-    List user IPS.
+    List user IPS, generic view
     """
-    def __init__(self, context, request):
-        self.context = context
-        self.request = request
 
     def _get_user_unique_ips(self, user, with_username=False):
         """
@@ -80,40 +77,33 @@ class ListUserIPs(BrowserView):
 
         return unique_ips
 
-    def unique(self):
-        """
-        List unique user IPs.
-        """
+    def get_app_links(self):
+        """ View function to pass function along to actual helper """
+        return get_app_links(self.context)
+
+class ListUniqueUserIPs(ListUserIPs):
+    """
+    BrowserView for List unique user IPs.
+    """
+
+    def get_unique_ips(self):
         users = api.user.get_users()
         ips = set()
         for user in users:
             ips.update(self._get_user_unique_ips(user, with_username=False))
 
-        template = self.context.restrictedTraverse('show_unique_user_ips')
-        template_context = get_app_links(self.context)
-        template_context.update({
-            'ips': ips,
-            'charset': 'utf-8'
-        })
-        rendered_template = template(**template_context)
+        return ips
 
-        return rendered_template
+class ListAllUserIPs(ListUserIPs):
+    """
+    BrowserView for List all user IPs.
+    """
 
-    def all(self):
-        """
-        List all user IPs.
-        """
+    def get_all_ips(self):
+
         users = api.user.get_users()
         ips = []
         for user in users:
             ips += self._get_user_ips(user, with_username=True)
 
-        template = self.context.restrictedTraverse('show_all_user_ips')
-        template_context = get_app_links(self.context)
-        template_context.update({
-            'ips': ips,
-            'charset': 'utf-8'
-        })
-        rendered_template = template(**template_context)
-
-        return rendered_template
+        return ips

--- a/src/collective/smsauthenticator/browser/templates/show_all_user_ips.pt
+++ b/src/collective/smsauthenticator/browser/templates/show_all_user_ips.pt
@@ -9,9 +9,10 @@
     <metal:main fill-slot="prefs_configlet_main">
         <tal:root define="lt string:&lt;;
                   gt string:&gt;;
-                  ips python:options['ips'];"
+                  ips view/get_all_ips;
+                  settings view/get_app_links"
                   >
-            <a id="setup-link" tal:attributes="href python:options['settings_url']" tal:content="python:options['settings_text']">
+            <a id="setup-link" tal:attributes="href settings/settings_url" tal:content="settings/settings_text">
                 SMS Authenticator configuration
             </a>
             <h1 class="documentFirstHeading" i18n:translate="">SMS Authenticator</h1>

--- a/src/collective/smsauthenticator/browser/templates/show_unique_user_ips.pt
+++ b/src/collective/smsauthenticator/browser/templates/show_unique_user_ips.pt
@@ -7,9 +7,10 @@
     <metal:main fill-slot="prefs_configlet_main">
         <tal:root define="lt string:&lt;;
                   gt string:&gt;;
-                  ips python:options['ips'];"
+                  ips view/get_unique_ips;
+                  settings view/get_app_links"
                   >
-            <a id="setup-link" tal:attributes="href python:options['settings_url']" tal:content="python:options['settings_text']">
+            <a id="setup-link" tal:attributes="href settings/settings_url" tal:content="settings/settings_text">
                 SMS Authenticator configuration
             </a>
             <h1 class="documentFirstHeading" i18n:translate="">SMS Authenticator</h1>


### PR DESCRIPTION
Get rid of skin folder template and use them as actual browserview template, more the plone-way :)
Make actual (sub)classes of the two views (ListUnique and ListAll) instead of attributes, allows us to use the templates.

The functions of both views are almost identical, could combine this further.. by renaming the function and moving it to the super class. Then define a method for each subclass. But that decreases readability.
