### PR TITLE
Only empty cookies if we're not doing a POST

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -5,6 +5,7 @@ Changelog
 ------------------------------------------------
 - Expand the uninstall functionality with proper removal of persistne objects [puittenbroek]
 - Better error logging [puittenbroek]
+- Don't logout user when doing a POST [puittenbroek]
 
 0.3.1 (2015-02-12)
 ------------------------------------------------

--- a/src/collective/smsauthenticator/browser/forms/token.py
+++ b/src/collective/smsauthenticator/browser/forms/token.py
@@ -195,7 +195,8 @@ class TokenForm(form.SchemaForm):
 
         request = self.request
         response = request['RESPONSE']
-        response.setCookie('__ac', '', path='/')
+        if not request['REQUEST_METHOD'] == 'POST':
+            response.setCookie('__ac', '', path='/')
 
         # Updating the description
         token_field = self.fields.get('token')


### PR DESCRIPTION
The updateFields method is also called after doing the submit via the enter key. Because we empty the __ac cookie, this will result in the user being logged out again. By checking if we're doing a POST we can fix this issue.

