### PR TITLE
Sync enable_two_step_verification with settings.globally_enabled

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -3,8 +3,9 @@ Changelog
 
 0.3.2 (unreleased)
 ------------------------------------------------
-- Add add defaultFactory to sync enable_two_step_verification with settings.globally_enabled
-  [pcdummy]
+- Set the default value of `enable_two_step_verification` for new users to the registry
+  setting `ISMSAuthenticatorSettings.globally_enabled` (see issue #15)
+  [pcdummy, fRiSi]
 - Expand the uninstall functionality with proper removal of persisent objects [puittenbroek]
 - Better error logging [puittenbroek]
 - Don't logout user when doing a POST [puittenbroek]

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -3,6 +3,8 @@ Changelog
 
 0.3.2 (unreleased)
 ------------------------------------------------
+- Add add defaultFactory to sync enable_two_step_verification with settings.globally_enabled
+  [pcdummy]
 - Expand the uninstall functionality with proper removal of persisent objects [puittenbroek]
 - Better error logging [puittenbroek]
 - Don't logout user when doing a POST [puittenbroek]
@@ -26,7 +28,7 @@ Changelog
 0.2.9 (2014-10-03)
 ------------------------------------------------
 - Fix: CL adduser fails due to plone.api, but adduser adds as a Zope account,
-  which doesn't need the twofactor properties. We shortcut the subscriber if 
+  which doesn't need the twofactor properties. We shortcut the subscriber if
   it's a Zope account being added. See plone.api docs for issue with 'scripts':
   http://docs.plone.org/external/plone.api/docs/api/exceptions.html#plone.api.exc.CannotGetPortalError
   [puittenbroek]
@@ -34,7 +36,7 @@ Changelog
 0.2.8 (2014-07-07)
 ------------------------------------------------
 
-- Use source_users IAutheticationPlugin for password check to prevent 
+- Use source_users IAutheticationPlugin for password check to prevent
   recursive loop [puittenbroek]
 - Better return values, we always return None in our pas plugin [puittenbroek]
 - Add 'enableAutoFocus' forms to enable auto focus [puittenbroek]

--- a/src/collective/smsauthenticator/userdataschema.py
+++ b/src/collective/smsauthenticator/userdataschema.py
@@ -1,20 +1,16 @@
-import logging
-
-from plone import api
-
-from zope.component import adapter
-from zope.schema import Bool, TextLine, Text
-from zope.i18nmessageid import MessageFactory
-from zope.interface import implements
-
-from plone.app.users.userdataschema import IUserDataSchema, IUserDataSchemaProvider
-from plone.app.users.browser.personalpreferences import UserDataPanel
-
+from Products.PlonePAS.plugins.ufactory import PloneUser
 from Products.PluggableAuthService.interfaces.authservice import IBasicUser
 from Products.PluggableAuthService.interfaces.events import IPrincipalCreatedEvent
-from Products.PlonePAS.plugins.ufactory import PloneUser
-
 from collective.smsauthenticator.helpers import get_app_settings
+from plone import api
+from plone.app.users.browser.personalpreferences import UserDataPanel
+from plone.app.users.userdataschema import IUserDataSchema, IUserDataSchemaProvider
+from zope.component import adapter
+from zope.i18nmessageid import MessageFactory
+from zope.interface import implements
+from zope.schema import Bool, TextLine, Text
+
+import logging
 
 
 logger = logging.getLogger("collective.smsauthenticator")
@@ -37,7 +33,7 @@ class CustomizedUserDataPanel(UserDataPanel):
             'mobile_number_reset_code',
             'mobile_number_authentication_code',
             'ips',
-            #'authentication_token_valid_until',
+            # 'authentication_token_valid_until',
             )
 
 
@@ -86,46 +82,46 @@ class IEnhancedUserDataSchema(IUserDataSchema):
         )
 
     mobile_number = TextLine(
-        title = _('Mobile number'),
-        description = _("Users' mobile number"),
-        required = False,
+        title=_('Mobile number'),
+        description=_("Users' mobile number"),
+        required=False,
     )
 
     two_step_verification_secret = TextLine(
-        title = _('Secret key'),
-        description = _('Automatically generated'),
-        required = False,
+        title=_('Secret key'),
+        description=_('Automatically generated'),
+        required=False,
     )
 
     mobile_number_reset_token = TextLine(
-        title = _('Token to reset the mobile number'),
-        description = _('Automatically generated'),
-        required = False,
+        title=_('Token to reset the mobile number'),
+        description=_('Automatically generated'),
+        required=False,
     )
 
     mobile_number_reset_code = TextLine(
-        title = _('Code to reset the mobile number (sent by SMS)'),
-        description = _('Automatically generated'),
-        required = False,
+        title=_('Code to reset the mobile number (sent by SMS)'),
+        description=_('Automatically generated'),
+        required=False,
     )
 
     mobile_number_authentication_code = TextLine(
-        title = _('Last authentication code'),
-        description = _('Automatically generated each time SMS message is sent'),
-        required = False,
+        title=_('Last authentication code'),
+        description=_('Automatically generated each time SMS message is sent'),
+        required=False,
     )
 
     ips = Text(
-        title = _('List of IPs user logged from'),
-        description = _('Automatically generated each time user logs in'),
-        required = False,
+        title=_('List of IPs user logged from'),
+        description=_('Automatically generated each time user logs in'),
+        required=False,
     )
 
-    #authentication_token_valid_until = TextLine(
+    # authentication_token_valid_until = TextLine(
     #    title = _('Last token valid until'),
     #    description = _('Automatically generated each time SMS message is sent'),
     #    required = False,
-    #)
+    # )
 
 
 @adapter(IBasicUser, IPrincipalCreatedEvent)
@@ -152,7 +148,7 @@ def userCreatedHandler(principal, event):
     user = api.user.get(username=principal.getId())
     if is_two_step_verification_globally_enabled():
         get_or_create_secret(user)
-        user.setMemberProperties(mapping={'enable_two_step_verification': True,})
+        user.setMemberProperties(mapping={'enable_two_step_verification': True})
 
     logger.debug(user.getProperty('enable_two_step_verification'))
     logger.debug(user.getProperty('two_step_verification_secret'))

--- a/src/collective/smsauthenticator/userdataschema.py
+++ b/src/collective/smsauthenticator/userdataschema.py
@@ -47,9 +47,9 @@ class UserDataSchemaProvider(object):
 
 
 def verification_default_enabled():
-    """ A helper function for the IEnhancedUserDataSchema below.
-        It returns the default for "enable_two_step_verification"
-        which is just the setting "globaly_enabled".
+    """
+    Returns the value of `ISMSAuthenticatorSettings.globally_enabled`.
+    Used as default value for `IEnhancedUserDataSchema.enable_two_step_verification`.
     """
     settings = get_app_settings()
     return settings.globally_enabled
@@ -78,7 +78,7 @@ class IEnhancedUserDataSchema(IUserDataSchema):
                       <a href='@@disable-two-step-verification'>here</a> to disable it."""
             ),
         required=False,
-        defaultFactory=verification_default_enabled
+        defaultFactory=verification_default_enabled,
         )
 
     mobile_number = TextLine(

--- a/src/collective/smsauthenticator/userdataschema.py
+++ b/src/collective/smsauthenticator/userdataschema.py
@@ -13,6 +13,10 @@ from plone.app.users.browser.personalpreferences import UserDataPanel
 from Products.PluggableAuthService.interfaces.authservice import IBasicUser
 from Products.PluggableAuthService.interfaces.events import IPrincipalCreatedEvent
 from Products.PlonePAS.plugins.ufactory import PloneUser
+
+from collective.smsauthenticator.helpers import get_app_settings
+
+
 logger = logging.getLogger("collective.smsauthenticator")
 
 _ = MessageFactory('collective.smsauthenticator')
@@ -46,6 +50,15 @@ class UserDataSchemaProvider(object):
         return IEnhancedUserDataSchema
 
 
+def verification_default_enabled():
+    """ A helper function for the IEnhancedUserDataSchema below.
+        It returns the default for "enable_two_step_verification"
+        which is just the setting "globaly_enabled".
+    """
+    settings = get_app_settings()
+    return settings.globally_enabled
+
+
 class IEnhancedUserDataSchema(IUserDataSchema):
     """
     Extended user profile.
@@ -68,7 +81,8 @@ class IEnhancedUserDataSchema(IUserDataSchema):
                       <a href='@@setup-mobile-number'>here</a> to set it up or\
                       <a href='@@disable-two-step-verification'>here</a> to disable it."""
             ),
-        required=False
+        required=False,
+        defaultFactory=verification_default_enabled
         )
 
     mobile_number = TextLine(


### PR DESCRIPTION
A very simple patch which makes ``enable_two_step_verificiation`` in user settings the default value of
``settings.globally_enabled``. It has been implemented as defaultFactory and has been suggested by @frisi in #15 

Can we/you do a release after this, we really need one for our customer?

Signed-off-by: Rene Jochum <rene@jochums.at>