### PR TITLE
use correct memberdata-property

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,6 +1,11 @@
 Changelog
 ================================================
 
+dev
+------------------------------------------------
+- use the correct memberdata property in the login-formcontroller-script.
+  (this used to work on a plone 4.3.9 portal, but broke the login process on 4.3.11) [fRiSi]
+
 0.3.2 (2016-05-25)
 ------------------------------------------------
 - Set the default value of `enable_two_step_verification` for new users to the registry

--- a/src/collective/smsauthenticator/skins/smsauthenticator_custom/login_next.cpy
+++ b/src/collective/smsauthenticator/skins/smsauthenticator_custom/login_next.cpy
@@ -53,7 +53,7 @@ if next:
     else:
         state.set(status='external')
 
-if member and not member.getProperty('enable_two_factor_authentication'):
+if member and not member.getProperty('enable_two_step_verification'):
     # If javascript is not enabled, it is possible that cookies are not enabled.
     # If cookies aren't enabled, the redirect will log the user out, and confusion
     # may arise.  Redirect only if we know for sure that cookies are enabled.


### PR DESCRIPTION
login_form worked on plone4.3.9, but on plone 4.3.11 we got a ValueError when logging in.

```
ValueError: The property enable_two_factor_authentication does not exist
```

The authentication code got sent via SMS, but validation resulted in a
"Invalid token or token expired" message.