### PR TITLE
Added Messagebird support

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,8 +1,13 @@
 Changelog
 ================================================
 
-0.3.4 (unreleased)
+0.3.5 (unreleased)
 -----------------------------------------------
+
+0.3.4 (2018-03-16)
+-----------------------------------------------
+- Added support for Messagebird SMS gateway provider.
+  For now, quite hard-coded, could be made more pluggable. [JJM]
 
 0.3.3 (2017-03-10)
 ------------------------------------------------

--- a/README.rst
+++ b/README.rst
@@ -246,6 +246,7 @@ Authors are listed in alphabetic order (by name):
 
 - Artur Barseghyan [barseghyanartur]
 - Harald Friessnegger[frisi]
+- Jan Murre [JJM]
 - Rene Jochum [pcdummy]
 - Peter Uittenbroek [puittenbroek]
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -5,7 +5,7 @@ collective.smsauthenticator
 for Plone 4 with use login codes sent by SMS. This app allows users to enable
 the two-step verification for their Plone accounts. A mobile phone capable to
 receive SMS messages is obviously required. Usage of two-step verification is
-optonal, unless site admins have forced it (configurable in app control panel).
+optional, unless site admins have forced it (configurable in app control panel).
 Admins can white-list the IPs, for which the two-step verification would be
 skipped.
 

--- a/setup.py
+++ b/setup.py
@@ -58,7 +58,7 @@ setup(
         'plone.directives.form>=1.1',
         'ska>=1.4.2',
         'rebus>=0.2',
-        'twilio>=5.4.0',
+        'twilio>=6.10.5',
         'messagebird'
     ],
     extras_require = {'test': ['plone.app.testing', 'robotsuite']},

--- a/setup.py
+++ b/setup.py
@@ -58,7 +58,8 @@ setup(
         'plone.directives.form>=1.1',
         'ska>=1.4.2',
         'rebus>=0.2',
-        'twilio>=5.4.0'
+        'twilio>=5.4.0',
+        'messagebird'
     ],
     extras_require = {'test': ['plone.app.testing', 'robotsuite']},
     entry_points = """

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import setup, find_packages
 import os
 
-version = '0.3.4dev0'
+version = '0.3.4'
 
 try:
     readme = open('README.rst').read()

--- a/src/collective/smsauthenticator/browser/controlpanel.py
+++ b/src/collective/smsauthenticator/browser/controlpanel.py
@@ -170,13 +170,14 @@ class SMSAuthenticatorSettingsEditForm(AutoExtensibleForm, form.EditForm):
             (u'Messagebird', MESSAGEBIRD_FIELDS)))
         for field_name in provider_fields_map[data['provider']]:
             if not data[field_name]:
-                # XXX add name of field i18n
+                field_title = ISMSAuthenticatorSettings.get(field_name).title
                 raise ActionExecutionError(
-                    Invalid(_(u'Field is required.')))
+                    Invalid(_(u'Field {0} is required.').format(field_title)))
             if field_name == 'message_bird_sender':
                 if not (2 < len(data[field_name]) < 12):
                     raise ActionExecutionError(
-                        Invalid(_(u'Field Messagebird sender between 3 and 11 chars.')))
+                        Invalid(
+                            _(u'Field Messagebird sender has to be between 3 and 11 chars.')))
 
     @button.buttonAndHandler(_(u"Save"), name='save')
     def handleSave(self, action):

--- a/src/collective/smsauthenticator/browser/controlpanel.py
+++ b/src/collective/smsauthenticator/browser/controlpanel.py
@@ -166,15 +166,17 @@ class SMSAuthenticatorSettingsEditForm(AutoExtensibleForm, form.EditForm):
         # Tried this with an invariant, but
         # did not get the right data in the param
         # of the invariant.
-        for provider_name, fields in (
-                (u'Twilio', TWILIO_FIELDS),
-                (u'Messagebird', MESSAGEBIRD_FIELDS)):
-            if data['provider'] == provider_name:
-                for field_name in fields:
-                    if not data[field_name]:
-                        # XXX add name of field i18n
-                        raise ActionExecutionError(
-                            Invalid(_(u'Field is required.')))
+        provider_fields_map = dict(((u'Twilio', TWILIO_FIELDS),
+            (u'Messagebird', MESSAGEBIRD_FIELDS)))
+        for field_name in provider_fields_map[data['provider']]:
+            if not data[field_name]:
+                # XXX add name of field i18n
+                raise ActionExecutionError(
+                    Invalid(_(u'Field is required.')))
+            if field_name == 'message_bird_sender':
+                if not (2 < len(data[field_name]) < 12):
+                    raise ActionExecutionError(
+                        Invalid(_(u'Field Messagebird sender between 3 and 11 chars.')))
 
     @button.buttonAndHandler(_(u"Save"), name='save')
     def handleSave(self, action):

--- a/src/collective/smsauthenticator/helpers.py
+++ b/src/collective/smsauthenticator/helpers.py
@@ -9,8 +9,8 @@ from plone.registry.interfaces import IRegistry
 from random import randint
 from requests.exceptions import RequestException
 from ska import sign_url, validate_signed_request_data
-from twilio.rest import TwilioRestClient
-from twilio.rest.exceptions import TwilioRestException as TwilioException
+from twilio.rest import Client as TwilioRestClient
+from twilio.base.exceptions import TwilioRestException as TwilioException
 from messagebird import Client as MessagebirdClient
 from messagebird.client import ErrorException as MessagebirdException
 from urllib import unquote, quote

--- a/src/collective/smsauthenticator/locales/collective.smsauthenticator.pot
+++ b/src/collective/smsauthenticator/locales/collective.smsauthenticator.pot
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2016-04-13 14:23+0000\n"
+"POT-Creation-Date: 2018-03-16 10:58+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -59,31 +59,31 @@ msgstr ""
 msgid "An error occured while sending the SMS to the number specified."
 msgstr ""
 
-#: ../browser/controlpanel.py:92
+#: ../browser/controlpanel.py:118
 msgid "Authentication token lifetime in seconds."
 msgstr ""
 
-#: ../userdataschema.py:82
+#: ../userdataschema.py:92
 msgid "Automatically generated"
 msgstr ""
 
-#: ../userdataschema.py:100
+#: ../userdataschema.py:110
 msgid "Automatically generated each time SMS message is sent"
 msgstr ""
 
-#: ../userdataschema.py:106
+#: ../userdataschema.py:116
 msgid "Automatically generated each time user logs in"
 msgstr ""
 
-#: ../browser/controlpanel.py:166
+#: ../browser/controlpanel.py:211
 msgid "Cancel"
 msgstr ""
 
-#: ../browser/controlpanel.py:163
+#: ../browser/controlpanel.py:206
 msgid "Changes saved."
 msgstr ""
 
-#: ../userdataschema.py:93
+#: ../userdataschema.py:103
 msgid "Code to reset the mobile number (sent by SMS)"
 msgstr ""
 
@@ -117,7 +117,7 @@ msgstr ""
 msgid "Disable two-step verification for all users"
 msgstr ""
 
-#: ../browser/controlpanel.py:168
+#: ../browser/controlpanel.py:214
 msgid "Edit cancelled."
 msgstr ""
 
@@ -129,11 +129,11 @@ msgstr ""
 msgid "Enable two-step verification for all users"
 msgstr ""
 
-#: ../userdataschema.py:66
+#: ../userdataschema.py:75
 msgid "Enable two-step verification."
 msgstr ""
 
-#: ../userdataschema.py:67
+#: ../userdataschema.py:76
 msgid ""
 "Enable/disable the two-step verification. Click                      <a "
 "href='@@setup-mobile-number'>here</a> to set it up or                      "
@@ -156,15 +156,19 @@ msgstr ""
 msgid "Enter the verification code you received on your mobile phone."
 msgstr ""
 
-#: ../browser/controlpanel.py:56
+#: ../browser/controlpanel.py:95
+msgid "Enter your Messagebird Access Key."
+msgstr ""
+
+#: ../browser/controlpanel.py:62
 msgid "Enter your Twilio (phone) number."
 msgstr ""
 
-#: ../browser/controlpanel.py:63
+#: ../browser/controlpanel.py:69
 msgid "Enter your Twilio AccountSID."
 msgstr ""
 
-#: ../browser/controlpanel.py:70
+#: ../browser/controlpanel.py:76
 msgid "Enter your Twilio AuthToken."
 msgstr ""
 
@@ -179,7 +183,7 @@ msgid ""
 "International number: +49234555776"
 msgstr ""
 
-#: ../browser/controlpanel.py:84
+#: ../browser/controlpanel.py:109
 msgid ""
 "Enter your secret key for the site here. When choosing a secret key, think "
 "of it as some sort of a password."
@@ -189,13 +193,25 @@ msgstr ""
 msgid "Enter your username for verification."
 msgstr ""
 
+#: ../browser/controlpanel.py:180
+msgid "Field Messagebird sender has to be between 3 and 11 chars."
+msgstr ""
+
+#: ../browser/controlpanel.py:175
+msgid "Field {0} is required."
+msgstr ""
+
 #: ../browser/disable_two_step_verification.py:23
 #: ../browser/forms/user_setup_mobile_number.py:51
 #: ../browser/forms/user_setup_two_step_verification.py:51
 msgid "Forbidden for anonymous"
 msgstr ""
 
-#: ../browser/controlpanel.py:32
+#: ../configure.zcml:34
+msgid "Forms for collective.smsauthenticator"
+msgstr ""
+
+#: ../browser/controlpanel.py:30
 msgid "Globally enabled"
 msgstr ""
 
@@ -204,7 +220,7 @@ msgstr ""
 msgid "IP"
 msgstr ""
 
-#: ../browser/controlpanel.py:33
+#: ../browser/controlpanel.py:31
 msgid ""
 "If checked, globally enables the two-step verification for all users; "
 "otherwise - each user configures it himself. Note, that unchecking the "
@@ -213,6 +229,10 @@ msgstr ""
 
 #: ../browser/forms/request_mobile_number_reset.py:55
 msgid "Important note"
+msgstr ""
+
+#: ../profiles.zcml:11
+msgid "Installs the collective.smsauthenticator package"
 msgstr ""
 
 #: ../browser/forms/token.py:105
@@ -241,11 +261,11 @@ msgstr ""
 msgid "Invalid username."
 msgstr ""
 
-#: ../userdataschema.py:99
+#: ../userdataschema.py:109
 msgid "Last authentication code"
 msgstr ""
 
-#: ../userdataschema.py:105
+#: ../userdataschema.py:115
 msgid "List of IPs user logged from"
 msgstr ""
 
@@ -253,18 +273,38 @@ msgstr ""
 msgid "Login failed"
 msgstr ""
 
-#: ../browser/controlpanel.py:49
-msgid "Main"
+#: ../browser/controlpanel.py:102
+msgid "Messagebird"
+msgstr ""
+
+#: ../browser/controlpanel.py:94
+msgid "Messagebird Access Key"
+msgstr ""
+
+#: ../browser/controlpanel.py:88
+msgid "Messagebird sender"
 msgstr ""
 
 #: ../browser/forms/request_mobile_number_reset.py:47
 #: ../browser/forms/user_setup_mobile_number.py:30
-#: ../userdataschema.py:75
+#: ../userdataschema.py:85
 msgid "Mobile number"
+msgstr ""
+
+#: ../browser/controlpanel.py:89
+msgid "Name of the sender, that users sees in SMS message."
+msgstr ""
+
+#: ../browser/controlpanel.py:209
+msgid "No changes were made."
 msgstr ""
 
 #: ../browser/forms/token.py:83
 msgid "No token provided!"
+msgstr ""
+
+#: ../browser/controlpanel.py:53
+msgid "Provider"
 msgstr ""
 
 #: ../browser/forms/request_mobile_number_reset.py:175
@@ -284,13 +324,21 @@ msgstr ""
 msgid "Resend SMS"
 msgstr ""
 
-#: ../browser/controlpanel.py:111
+#: ../browser/controlpanel.py:137
 #: ../browser/templates/show_all_user_ips.pt:18
 #: ../browser/templates/show_unique_user_ips.pt:16
 msgid "SMS Authenticator"
 msgstr ""
 
-#: ../browser/controlpanel.py:112
+#: ../configure.zcml:34
+msgid "SMS Authenticator Plone"
+msgstr ""
+
+#: ../configure.zcml:42
+msgid "SMS Authenticator Plone Action Uninstall"
+msgstr ""
+
+#: ../browser/controlpanel.py:138
 #: ../browser/helpers.py:12
 msgid "SMS Authenticator configuration"
 msgstr ""
@@ -299,19 +347,19 @@ msgstr ""
 msgid "SMS verification code"
 msgstr ""
 
-#: ../browser/controlpanel.py:136
+#: ../browser/controlpanel.py:182
 msgid "Save"
 msgstr ""
 
-#: ../browser/controlpanel.py:83
+#: ../browser/controlpanel.py:108
 msgid "Secret Key"
 msgstr ""
 
-#: ../userdataschema.py:81
+#: ../userdataschema.py:91
 msgid "Secret key"
 msgstr ""
 
-#: ../browser/controlpanel.py:99
+#: ../browser/controlpanel.py:125
 msgid "Security"
 msgstr ""
 
@@ -341,33 +389,37 @@ msgstr ""
 msgid "Submit"
 msgstr ""
 
+#: ../browser/controlpanel.py:54
+msgid "The SMS gateway provider"
+msgstr ""
+
 #: ../browser/forms/user_setup_mobile_number.py:44
 msgid ""
 "To setup two-step verification you need to enter your mobile phone numberto "
 "which you will be receiving SMS messages with login codes."
 msgstr ""
 
-#: ../browser/controlpanel.py:91
+#: ../browser/controlpanel.py:117
 msgid "Token lifetime"
 msgstr ""
 
-#: ../userdataschema.py:87
+#: ../userdataschema.py:97
 msgid "Token to reset the mobile number"
 msgstr ""
 
-#: ../browser/controlpanel.py:77
+#: ../browser/controlpanel.py:83
 msgid "Twilio"
 msgstr ""
 
-#: ../browser/controlpanel.py:62
+#: ../browser/controlpanel.py:68
 msgid "Twilio AccountSID"
 msgstr ""
 
-#: ../browser/controlpanel.py:69
+#: ../browser/controlpanel.py:75
 msgid "Twilio AuthToken"
 msgstr ""
 
-#: ../browser/controlpanel.py:55
+#: ../browser/controlpanel.py:61
 msgid "Twilio number"
 msgstr ""
 
@@ -375,7 +427,7 @@ msgstr ""
 msgid "Two-step verification"
 msgstr ""
 
-#: ../pas_plugin.py:130
+#: ../pas_plugin.py:138
 msgid ""
 "Two-step verification is enabled for your account, but you haven't specified "
 "a mobile number yet! In order to be able to log in, you have to go through "
@@ -386,10 +438,22 @@ msgstr ""
 msgid "Two-step verification is successfully enabled for your account."
 msgstr ""
 
-#: ../browser/controlpanel.py:41
+#: ../browser/controlpanel.py:39
 msgid ""
 "Two-step verification will be ommit for users that log in from white listed "
 "addresses."
+msgstr ""
+
+#: ../browser/controlpanel.py:46
+msgid "Two-step verification will be ommited for users in this list."
+msgstr ""
+
+#: ../configure.zcml:42
+msgid "Uninstall Postlogin Action"
+msgstr ""
+
+#: ../profiles.zcml:19
+msgid "Uninstalls the collective.smsauthenticator package"
 msgstr ""
 
 #: ../browser/templates/show_unique_user_ips.pt:19
@@ -400,15 +464,15 @@ msgstr ""
 msgid "Use the form below to (re)set your mobile phone number."
 msgstr ""
 
-#: ../helpers.py:524
+#: ../helpers.py:590
 msgid "Use this code to confirm your mobile phone reset: ${code}"
 msgstr ""
 
-#: ../helpers.py:546
+#: ../helpers.py:616
 msgid "Use this code to confirm your mobile phone setup: ${code}"
 msgstr ""
 
-#: ../helpers.py:535
+#: ../helpers.py:603
 msgid "Use this code to login: ${code}"
 msgstr ""
 
@@ -424,7 +488,7 @@ msgstr ""
 msgid "Username"
 msgstr ""
 
-#: ../userdataschema.py:76
+#: ../userdataschema.py:86
 msgid "Users' mobile number"
 msgstr ""
 
@@ -438,8 +502,12 @@ msgstr ""
 msgid "Welcome! You are now logged in."
 msgstr ""
 
-#: ../browser/controlpanel.py:40
+#: ../browser/controlpanel.py:38
 msgid "White-listed IP addresses"
+msgstr ""
+
+#: ../browser/controlpanel.py:45
+msgid "White-listed User id"
 msgstr ""
 
 #: ../browser/forms/reset_mobile_number.py:61
@@ -479,8 +547,15 @@ msgstr ""
 msgid "Your SMS has just been resent."
 msgstr ""
 
+#: ../profiles.zcml:11
+msgid "collective.smsauthenticator"
+msgstr ""
+
+#: ../profiles.zcml:19
+msgid "collective.smsauthenticator uninstall"
+msgstr ""
+
 #. Default: "Enter the login code sent to your mobile number\nIf you have somehow lost your mobile number, request a reset\n<a href='${absolute_url}/@@request-mobile-number-reset'>here</a>.\nIf you didn't receive an SMS message, resend it by clicking\nthe Resend SMS button below."
 #: ../browser/forms/token.py:208
 msgid "token_field_description"
 msgstr ""
-

--- a/src/collective/smsauthenticator/locales/de/LC_MESSAGES/collective.smsauthenticator.po
+++ b/src/collective/smsauthenticator/locales/de/LC_MESSAGES/collective.smsauthenticator.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: \n"
-"POT-Creation-Date: 2016-04-13 14:23+0000\n"
+"POT-Creation-Date: 2018-03-16 10:58+0000\n"
 "PO-Revision-Date: 2016-05-03 10:58+0200\n"
 "Last-Translator: Rene Jochum <info@smile4.at>\n"
 "Language-Team: \n"
@@ -69,31 +69,31 @@ msgid "An error occured while sending the SMS to the number specified."
 msgstr ""
 "Während dem Versand der SMS an die spezifizierte Nummer trat ein Fehler auf."
 
-#: ../browser/controlpanel.py:92
+#: ../browser/controlpanel.py:118
 msgid "Authentication token lifetime in seconds."
 msgstr "Authentifizierungstoken Gültigkeitsdauer in Sekunden."
 
-#: ../userdataschema.py:82
+#: ../userdataschema.py:92
 msgid "Automatically generated"
 msgstr "Automatisch generiert"
 
-#: ../userdataschema.py:100
+#: ../userdataschema.py:110
 msgid "Automatically generated each time SMS message is sent"
 msgstr "Jedes mal wenn eine SMS gesendet wird Automatisch generiert."
 
-#: ../userdataschema.py:106
+#: ../userdataschema.py:116
 msgid "Automatically generated each time user logs in"
 msgstr "Jedes mal wenn der Benutzer sich anmeldet automatisch generiert "
 
-#: ../browser/controlpanel.py:166
+#: ../browser/controlpanel.py:211
 msgid "Cancel"
 msgstr "Abbrechen"
 
-#: ../browser/controlpanel.py:163
+#: ../browser/controlpanel.py:206
 msgid "Changes saved."
 msgstr "Änderungen gespeichert."
 
-#: ../userdataschema.py:93
+#: ../userdataschema.py:103
 msgid "Code to reset the mobile number (sent by SMS)"
 msgstr "Code um die Handynummer zurückzusetzen (Als SMS versand)"
 
@@ -138,7 +138,7 @@ msgstr "2-Faktor Authentifizierung abschalten"
 msgid "Disable two-step verification for all users"
 msgstr "2-Faktor Authentifizierung für alle Benutzer abschalten"
 
-#: ../browser/controlpanel.py:168
+#: ../browser/controlpanel.py:214
 msgid "Edit cancelled."
 msgstr "Bearbeitung abgebrochen."
 
@@ -150,11 +150,11 @@ msgstr "2-Faktor Authentifizierung einschalten"
 msgid "Enable two-step verification for all users"
 msgstr "2-Faktor Authentifizierung für alle Benutzer einschalten"
 
-#: ../userdataschema.py:66
+#: ../userdataschema.py:75
 msgid "Enable two-step verification."
 msgstr "2-Faktor Authentifizierung einschalten."
 
-#: ../userdataschema.py:67
+#: ../userdataschema.py:76
 msgid ""
 "Enable/disable the two-step verification. Click                      <a "
 "href='@@setup-mobile-number'>here</a> to set it up or                      "
@@ -184,15 +184,19 @@ msgstr ""
 msgid "Enter the verification code you received on your mobile phone."
 msgstr "Geben Sie den Verifiezierungscode den Sie per SMS erhalten habe ein."
 
-#: ../browser/controlpanel.py:56
+#: ../browser/controlpanel.py:95
+msgid "Enter your Messagebird Access Key."
+msgstr ""
+
+#: ../browser/controlpanel.py:62
 msgid "Enter your Twilio (phone) number."
 msgstr "Geben Sie Ihre Twilio (Telefon) Nummer ein."
 
-#: ../browser/controlpanel.py:63
+#: ../browser/controlpanel.py:69
 msgid "Enter your Twilio AccountSID."
 msgstr "Geben Sie Ihre Twilio AccountSID ein."
 
-#: ../browser/controlpanel.py:70
+#: ../browser/controlpanel.py:76
 msgid "Enter your Twilio AuthToken."
 msgstr "Geben Sie Ihren Twilio AuthToken ein."
 
@@ -202,14 +206,14 @@ msgstr "Geben Sie die Handynummer für die 2-Faktor Authentifizierung ein."
 
 #: ../browser/forms/request_mobile_number_reset.py:48
 msgid ""
-"Enter your mobile phone number. Use the international format.            <br/"
-">Example Dutch number: +31699555555            <br/>Example International "
-"number: +49234555776"
+"Enter your mobile phone number. Use the international format.            "
+"<br/>Example Dutch number: +31699555555            <br/>Example "
+"International number: +49234555776"
 msgstr ""
-"Geben Sie Ihre Handynummer ein. Benutzen Sie das internationale Format. \t"
-"\t<br/>Als Beispiel: +43664123123123"
+"Geben Sie Ihre Handynummer ein. Benutzen Sie das internationale Format. "
+"\t\t<br/>Als Beispiel: +43664123123123"
 
-#: ../browser/controlpanel.py:84
+#: ../browser/controlpanel.py:109
 msgid ""
 "Enter your secret key for the site here. When choosing a secret key, think "
 "of it as some sort of a password."
@@ -221,13 +225,25 @@ msgstr ""
 msgid "Enter your username for verification."
 msgstr "Geben Sie zur Verifizierung Ihren Benutzernamen an."
 
+#: ../browser/controlpanel.py:180
+msgid "Field Messagebird sender has to be between 3 and 11 chars."
+msgstr ""
+
+#: ../browser/controlpanel.py:175
+msgid "Field {0} is required."
+msgstr ""
+
 #: ../browser/disable_two_step_verification.py:23
 #: ../browser/forms/user_setup_mobile_number.py:51
 #: ../browser/forms/user_setup_two_step_verification.py:51
 msgid "Forbidden for anonymous"
 msgstr "Unzulässig für anonyme Benutzer"
 
-#: ../browser/controlpanel.py:32
+#: ../configure.zcml:34
+msgid "Forms for collective.smsauthenticator"
+msgstr ""
+
+#: ../browser/controlpanel.py:30
 msgid "Globally enabled"
 msgstr "Global eingeschaltet"
 
@@ -236,7 +252,7 @@ msgstr "Global eingeschaltet"
 msgid "IP"
 msgstr "IP"
 
-#: ../browser/controlpanel.py:33
+#: ../browser/controlpanel.py:31
 msgid ""
 "If checked, globally enables the two-step verification for all users; "
 "otherwise - each user configures it himself. Note, that unchecking the "
@@ -250,6 +266,10 @@ msgstr ""
 #: ../browser/forms/request_mobile_number_reset.py:55
 msgid "Important note"
 msgstr "Wichtige Notiz"
+
+#: ../profiles.zcml:11
+msgid "Installs the collective.smsauthenticator package"
+msgstr ""
 
 #: ../browser/forms/token.py:105
 msgid "Invalid data. Details: {0}"
@@ -267,7 +287,8 @@ msgstr "Ungültiger Zurücksetzungstoken."
 msgid "Invalid mobile number."
 msgstr "Falsche Handynummer."
 
-#: ../browser/forms/reset_mobile_number.py:138 ../browser/forms/token.py:127
+#: ../browser/forms/reset_mobile_number.py:138
+#: ../browser/forms/token.py:127
 #: ../browser/forms/user_setup_two_step_verification.py:86
 msgid "Invalid token or token expired."
 msgstr "Falscher Token oder der Token ist abgelaufen."
@@ -276,11 +297,11 @@ msgstr "Falscher Token oder der Token ist abgelaufen."
 msgid "Invalid username."
 msgstr "Falscher Benutzername."
 
-#: ../userdataschema.py:99
+#: ../userdataschema.py:109
 msgid "Last authentication code"
 msgstr "Letzter Authentifizierungscode"
 
-#: ../userdataschema.py:105
+#: ../userdataschema.py:115
 msgid "List of IPs user logged from"
 msgstr "Liste mit IPs der aktiven Anmeldungen des Benutzers"
 
@@ -288,18 +309,39 @@ msgstr "Liste mit IPs der aktiven Anmeldungen des Benutzers"
 msgid "Login failed"
 msgstr "Anmeldung fehlgeschlagen"
 
-#: ../browser/controlpanel.py:49
-msgid "Main"
+#: ../browser/controlpanel.py:102
+msgid "Messagebird"
+msgstr ""
+
+#: ../browser/controlpanel.py:94
+msgid "Messagebird Access Key"
+msgstr ""
+
+#: ../browser/controlpanel.py:88
+msgid "Messagebird sender"
 msgstr ""
 
 #: ../browser/forms/request_mobile_number_reset.py:47
-#: ../browser/forms/user_setup_mobile_number.py:30 ../userdataschema.py:75
+#: ../browser/forms/user_setup_mobile_number.py:30
+#: ../userdataschema.py:85
 msgid "Mobile number"
 msgstr "Handynummer"
+
+#: ../browser/controlpanel.py:89
+msgid "Name of the sender, that users sees in SMS message."
+msgstr ""
+
+#: ../browser/controlpanel.py:209
+msgid "No changes were made."
+msgstr ""
 
 #: ../browser/forms/token.py:83
 msgid "No token provided!"
 msgstr "Kein Token angegeben."
+
+#: ../browser/controlpanel.py:53
+msgid "Provider"
+msgstr ""
 
 #: ../browser/forms/request_mobile_number_reset.py:175
 msgid "Request for mobile number reset is failed! {0}"
@@ -319,12 +361,22 @@ msgstr "Die Handynummer für die 2-Faktor Authentifizierung zurücksetzen."
 msgid "Resend SMS"
 msgstr "SMS Erneut senden"
 
-#: ../browser/controlpanel.py:111 ../browser/templates/show_all_user_ips.pt:18
+#: ../browser/controlpanel.py:137
+#: ../browser/templates/show_all_user_ips.pt:18
 #: ../browser/templates/show_unique_user_ips.pt:16
 msgid "SMS Authenticator"
 msgstr "SMS Anmeldung"
 
-#: ../browser/controlpanel.py:112 ../browser/helpers.py:12
+#: ../configure.zcml:34
+msgid "SMS Authenticator Plone"
+msgstr ""
+
+#: ../configure.zcml:42
+msgid "SMS Authenticator Plone Action Uninstall"
+msgstr ""
+
+#: ../browser/controlpanel.py:138
+#: ../browser/helpers.py:12
 msgid "SMS Authenticator configuration"
 msgstr "SMS Anmeldungen Konfiguration"
 
@@ -332,19 +384,19 @@ msgstr "SMS Anmeldungen Konfiguration"
 msgid "SMS verification code"
 msgstr "SMS Verifizierungscode"
 
-#: ../browser/controlpanel.py:136
+#: ../browser/controlpanel.py:182
 msgid "Save"
 msgstr "Speichern"
 
-#: ../browser/controlpanel.py:83
+#: ../browser/controlpanel.py:108
 msgid "Secret Key"
 msgstr "Geheimer Schlüssel"
 
-#: ../userdataschema.py:81
+#: ../userdataschema.py:91
 msgid "Secret key"
 msgstr "Geheimer Schlüssel"
 
-#: ../browser/controlpanel.py:99
+#: ../browser/controlpanel.py:125
 msgid "Security"
 msgstr "Sicherheit"
 
@@ -374,6 +426,10 @@ msgstr "Eindeutige Benutzer IPs anzeigen"
 msgid "Submit"
 msgstr "Abschicken"
 
+#: ../browser/controlpanel.py:54
+msgid "The SMS gateway provider"
+msgstr ""
+
 #: ../browser/forms/user_setup_mobile_number.py:44
 msgid ""
 "To setup two-step verification you need to enter your mobile phone numberto "
@@ -382,27 +438,27 @@ msgstr ""
 "Um die 2-Faktor Authentifizierung einzurichten müssen Sie Ihre Handynummer "
 "eingegeben zu welcher Sie SMS Nachrichten mit Anmeldungscodes erhalten.‪"
 
-#: ../browser/controlpanel.py:91
+#: ../browser/controlpanel.py:117
 msgid "Token lifetime"
 msgstr "Token Lebenszeit"
 
-#: ../userdataschema.py:87
+#: ../userdataschema.py:97
 msgid "Token to reset the mobile number"
 msgstr "Token um die Handynummer zurückzusetzen"
 
-#: ../browser/controlpanel.py:77
+#: ../browser/controlpanel.py:83
 msgid "Twilio"
 msgstr "Twilio"
 
-#: ../browser/controlpanel.py:62
+#: ../browser/controlpanel.py:68
 msgid "Twilio AccountSID"
 msgstr "Twilio \"AccountSID\""
 
-#: ../browser/controlpanel.py:69
+#: ../browser/controlpanel.py:75
 msgid "Twilio AuthToken"
 msgstr "Twilio \"AuthToken\""
 
-#: ../browser/controlpanel.py:55
+#: ../browser/controlpanel.py:61
 msgid "Twilio number"
 msgstr "Twilio Nummer"
 
@@ -410,7 +466,7 @@ msgstr "Twilio Nummer"
 msgid "Two-step verification"
 msgstr "2-Faktor Authentifizierung"
 
-#: ../pas_plugin.py:130
+#: ../pas_plugin.py:138
 msgid ""
 "Two-step verification is enabled for your account, but you haven't specified "
 "a mobile number yet! In order to be able to log in, you have to go through "
@@ -426,13 +482,25 @@ msgstr ""
 "Die 2-Faktor Authentifizierung wurde für Ihren Account erfolgreich "
 "eingeschaltet."
 
-#: ../browser/controlpanel.py:41
+#: ../browser/controlpanel.py:39
 msgid ""
 "Two-step verification will be ommit for users that log in from white listed "
 "addresses."
 msgstr ""
 "Die 2-Faktor Authentifizierung wird für mit folgenden IP Adressen "
 "abgeschaltet."
+
+#: ../browser/controlpanel.py:46
+msgid "Two-step verification will be ommited for users in this list."
+msgstr ""
+
+#: ../configure.zcml:42
+msgid "Uninstall Postlogin Action"
+msgstr ""
+
+#: ../profiles.zcml:19
+msgid "Uninstalls the collective.smsauthenticator package"
+msgstr ""
 
 #: ../browser/templates/show_unique_user_ips.pt:19
 msgid "Unique user IPs"
@@ -443,15 +511,15 @@ msgid "Use the form below to (re)set your mobile phone number."
 msgstr ""
 "Benutzen Sie dieses Formular um Ihre Handynummer zu setzen/zurückzusetzen."
 
-#: ../helpers.py:524
+#: ../helpers.py:590
 msgid "Use this code to confirm your mobile phone reset: ${code}"
 msgstr "Benutzen Sie diesen Code um die Änderung zu bestätigen: ${code}"
 
-#: ../helpers.py:546
+#: ../helpers.py:616
 msgid "Use this code to confirm your mobile phone setup: ${code}"
 msgstr "Benutzen Sie diesen Code um die Einrichtung abzuschliessen: ${code}"
 
-#: ../helpers.py:535
+#: ../helpers.py:603
 msgid "Use this code to login: ${code}"
 msgstr "Benutzen Sie diesen Code um sich anzumelden: ${code}"
 
@@ -467,11 +535,12 @@ msgstr "Benutzer {0} nicht gefunden."
 msgid "Username"
 msgstr "Benutzername"
 
-#: ../userdataschema.py:76
+#: ../userdataschema.py:86
 msgid "Users' mobile number"
 msgstr "Die Handynummer des Benutzer's"
 
-#: ../browser/forms/reset_mobile_number.py:71 ../browser/forms/token.py:60
+#: ../browser/forms/reset_mobile_number.py:71
+#: ../browser/forms/token.py:60
 #: ../browser/forms/user_setup_mobile_number.py:48
 msgid "Verify"
 msgstr "Überprüfen"
@@ -480,9 +549,13 @@ msgstr "Überprüfen"
 msgid "Welcome! You are now logged in."
 msgstr "Willkommen! Sie sind nun angemeldet."
 
-#: ../browser/controlpanel.py:40
+#: ../browser/controlpanel.py:38
 msgid "White-listed IP addresses"
 msgstr "IP Adressen ohne 2-Faktor authentifizierung"
+
+#: ../browser/controlpanel.py:45
+msgid "White-listed User id"
+msgstr ""
 
 #: ../browser/forms/reset_mobile_number.py:61
 msgid ""
@@ -490,8 +563,8 @@ msgid ""
 "code.        <br/>After successfully submitting this form, you will be "
 "automatically logged in."
 msgstr ""
-"Sie haben (oder werden in kürze) einen SMS Verifizierungscode erhalten. <br/"
-"> Nachdem Sie dieses Formular abgeschickt haben werden Sie automatisch "
+"Sie haben (oder werden in kürze) einen SMS Verifizierungscode erhalten. "
+"<br/> Nachdem Sie dieses Formular abgeschickt haben werden Sie automatisch "
 "eingeloggt."
 
 #: ../browser/forms/reset_mobile_number.py:124
@@ -501,7 +574,8 @@ msgid ""
 msgstr "Sie haben die Handynummer erfolgreich gesetzt."
 
 #: ../browser/disable_two_step_verification_for_all_users.py:28
-msgid "You have successfully disabled the two-step verification for all users."
+msgid ""
+"You have successfully disabled the two-step verification for all users."
 msgstr ""
 "Sie haben die 2-Faktor Authentifizierung erfolgreich für alle Benutzer "
 "abgeschaltet."
@@ -530,11 +604,20 @@ msgstr ""
 msgid "Your SMS has just been resent."
 msgstr "Ihr SMS wurde erneut verschickt."
 
+#: ../profiles.zcml:11
+msgid "collective.smsauthenticator"
+msgstr ""
+
+#: ../profiles.zcml:19
+msgid "collective.smsauthenticator uninstall"
+msgstr ""
+
 #. Default: "Enter the login code sent to your mobile number\nIf you have somehow lost your mobile number, request a reset\n<a href='${absolute_url}/@@request-mobile-number-reset'>here</a>.\nIf you didn't receive an SMS message, resend it by clicking\nthe Resend SMS button below."
 #: ../browser/forms/token.py:208
 msgid "token_field_description"
 msgstr ""
 "Geben Sie den Anmeldungscode den Sie per SMS erhalten haben ein. Wenn Sie "
-"Ihre Handynummer verloren haben klicken Sie bitte <a href='${absolute_url}/"
-"@@request-mobile-number-reset'>hier</a>. Wenn Sie keine SMS erhalten haben "
-"klicken Sie bitte auf den \"SMS Erneut senden\" Knopf unten."
+"Ihre Handynummer verloren haben klicken Sie bitte <a "
+"href='${absolute_url}/@@request-mobile-number-reset'>hier</a>. Wenn Sie "
+"keine SMS erhalten haben klicken Sie bitte auf den \"SMS Erneut senden\" "
+"Knopf unten."

--- a/src/collective/smsauthenticator/locales/nl/LC_MESSAGES/collective.smsauthenticator.po
+++ b/src/collective/smsauthenticator/locales/nl/LC_MESSAGES/collective.smsauthenticator.po
@@ -14,7 +14,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: 1.0\n"
-"POT-Creation-Date: 2016-04-13 14:23+0000\n"
+"POT-Creation-Date: 2018-03-16 10:58+0000\n"
 "PO-Revision-Date: 2015-02-12 16:59+0100\n"
 "Last-Translator: Artur Barseghyan <barseghyan@goldmund-wyldebeast-wunderliebe.com>\n"
 "Language-Team: Dutch\n"
@@ -79,31 +79,31 @@ msgstr ""
 "Er is een fout opgetreden bij het verzenden van de SMS naar het opgegeven "
 "nummer."
 
-#: ../browser/controlpanel.py:92
+#: ../browser/controlpanel.py:118
 msgid "Authentication token lifetime in seconds."
 msgstr "Authenticatie token leeftijd in seconden."
 
-#: ../userdataschema.py:82
+#: ../userdataschema.py:92
 msgid "Automatically generated"
 msgstr "Automatisch gegenereerd"
 
-#: ../userdataschema.py:100
+#: ../userdataschema.py:110
 msgid "Automatically generated each time SMS message is sent"
 msgstr "Automatisch gegenereerd elke keer dat SMS bericht wordt verzonden"
 
-#: ../userdataschema.py:106
+#: ../userdataschema.py:116
 msgid "Automatically generated each time user logs in"
 msgstr "Automatisch gegenereerd elke keer dat de gebruiker zich aanmeldt"
 
-#: ../browser/controlpanel.py:166
+#: ../browser/controlpanel.py:211
 msgid "Cancel"
 msgstr "Annuleren"
 
-#: ../browser/controlpanel.py:163
+#: ../browser/controlpanel.py:206
 msgid "Changes saved."
 msgstr "Wijzigingen opgeslagen."
 
-#: ../userdataschema.py:93
+#: ../userdataschema.py:103
 msgid "Code to reset the mobile number (sent by SMS)"
 msgstr "Code om de mobiele nummer te resetten (verstuurd doormiddel een SMS)"
 
@@ -140,7 +140,7 @@ msgstr "Twee-stap verificatie uitschakelen"
 msgid "Disable two-step verification for all users"
 msgstr "Twee-stap verificatie uitschakelen voor alle gebruikers"
 
-#: ../browser/controlpanel.py:168
+#: ../browser/controlpanel.py:214
 msgid "Edit cancelled."
 msgstr "Bewerken geannuleerd."
 
@@ -152,11 +152,11 @@ msgstr "Twee-stap verificatie inschakelen"
 msgid "Enable two-step verification for all users"
 msgstr "Twee-stap verificatie inschakelen voor alle gebruikers"
 
-#: ../userdataschema.py:66
+#: ../userdataschema.py:75
 msgid "Enable two-step verification."
 msgstr "Schakel twee-stap verificatie in."
 
-#: ../userdataschema.py:67
+#: ../userdataschema.py:76
 msgid ""
 "Enable/disable the two-step verification. Click                      <a "
 "href='@@setup-mobile-number'>here</a> to set it up or                      "
@@ -182,15 +182,19 @@ msgstr "Voer de verificatiecode om twee-stappen verificatie te activeren"
 msgid "Enter the verification code you received on your mobile phone."
 msgstr "Voer de verificatiecode die u op uw mobiele telefoon ontvangen."
 
-#: ../browser/controlpanel.py:56
+#: ../browser/controlpanel.py:95
+msgid "Enter your Messagebird Access Key."
+msgstr ""
+
+#: ../browser/controlpanel.py:62
 msgid "Enter your Twilio (phone) number."
 msgstr "Voer uw Twilio (telefoon) nummer in."
 
-#: ../browser/controlpanel.py:63
+#: ../browser/controlpanel.py:69
 msgid "Enter your Twilio AccountSID."
 msgstr "Voer uw Twilio AccountSID in."
 
-#: ../browser/controlpanel.py:70
+#: ../browser/controlpanel.py:76
 msgid "Enter your Twilio AuthToken."
 msgstr "Voer uw Twilio AuthToken in."
 
@@ -209,7 +213,7 @@ msgstr ""
 "Voorbeeld Nederlandse nummer: +31699555555 <br/> Voorbeeld International "
 "nummer: +49234555776"
 
-#: ../browser/controlpanel.py:84
+#: ../browser/controlpanel.py:109
 msgid ""
 "Enter your secret key for the site here. When choosing a secret key, think "
 "of it as some sort of a password."
@@ -221,13 +225,25 @@ msgstr ""
 msgid "Enter your username for verification."
 msgstr "Voer uw gebruikersnaam voor verificatie."
 
+#: ../browser/controlpanel.py:180
+msgid "Field Messagebird sender has to be between 3 and 11 chars."
+msgstr "Het veld Messagebird sender moet 3 - 11 chars groot zijn."
+
+#: ../browser/controlpanel.py:175
+msgid "Field {0} is required."
+msgstr "Het veld {0} is verplicht."
+
 #: ../browser/disable_two_step_verification.py:23
 #: ../browser/forms/user_setup_mobile_number.py:51
 #: ../browser/forms/user_setup_two_step_verification.py:51
 msgid "Forbidden for anonymous"
 msgstr "Verboden voor anonieme gebruikers"
 
-#: ../browser/controlpanel.py:32
+#: ../configure.zcml:34
+msgid "Forms for collective.smsauthenticator"
+msgstr ""
+
+#: ../browser/controlpanel.py:30
 msgid "Globally enabled"
 msgstr "Globaal ingeschakeld"
 
@@ -236,7 +252,7 @@ msgstr "Globaal ingeschakeld"
 msgid "IP"
 msgstr ""
 
-#: ../browser/controlpanel.py:33
+#: ../browser/controlpanel.py:31
 msgid ""
 "If checked, globally enables the two-step verification for all users; "
 "otherwise - each user configures it himself. Note, that unchecking the "
@@ -249,6 +265,10 @@ msgstr ""
 
 #: ../browser/forms/request_mobile_number_reset.py:55
 msgid "Important note"
+msgstr ""
+
+#: ../profiles.zcml:11
+msgid "Installs the collective.smsauthenticator package"
 msgstr ""
 
 #: ../browser/forms/token.py:105
@@ -277,11 +297,11 @@ msgstr "Ongeldig token of token verlopen."
 msgid "Invalid username."
 msgstr "Ongeldige gebruikersnaam."
 
-#: ../userdataschema.py:99
+#: ../userdataschema.py:109
 msgid "Last authentication code"
 msgstr "Laatste authenticatie code"
 
-#: ../userdataschema.py:105
+#: ../userdataschema.py:115
 msgid "List of IPs user logged from"
 msgstr "Lijst van IPs van ingelogde gebruikers"
 
@@ -289,19 +309,39 @@ msgstr "Lijst van IPs van ingelogde gebruikers"
 msgid "Login failed"
 msgstr "Inloggen mislukt"
 
-#: ../browser/controlpanel.py:49
-msgid "Main"
-msgstr "Algemeen"
+#: ../browser/controlpanel.py:102
+msgid "Messagebird"
+msgstr ""
+
+#: ../browser/controlpanel.py:94
+msgid "Messagebird Access Key"
+msgstr ""
+
+#: ../browser/controlpanel.py:88
+msgid "Messagebird sender"
+msgstr ""
 
 #: ../browser/forms/request_mobile_number_reset.py:47
 #: ../browser/forms/user_setup_mobile_number.py:30
-#: ../userdataschema.py:75
+#: ../userdataschema.py:85
 msgid "Mobile number"
 msgstr "Mobiel nummer"
+
+#: ../browser/controlpanel.py:89
+msgid "Name of the sender, that users sees in SMS message."
+msgstr ""
+
+#: ../browser/controlpanel.py:209
+msgid "No changes were made."
+msgstr ""
 
 #: ../browser/forms/token.py:83
 msgid "No token provided!"
 msgstr "Geen token verstrekt!"
+
+#: ../browser/controlpanel.py:53
+msgid "Provider"
+msgstr ""
 
 #: ../browser/forms/request_mobile_number_reset.py:175
 msgid "Request for mobile number reset is failed! {0}"
@@ -320,13 +360,21 @@ msgstr "Verzoek om de SMS Authenticator mobiele nummer opnieuw in te stellen"
 msgid "Resend SMS"
 msgstr "SMS opnieuw verzenden"
 
-#: ../browser/controlpanel.py:111
+#: ../browser/controlpanel.py:137
 #: ../browser/templates/show_all_user_ips.pt:18
 #: ../browser/templates/show_unique_user_ips.pt:16
 msgid "SMS Authenticator"
 msgstr "SMS Authenticator"
 
-#: ../browser/controlpanel.py:112
+#: ../configure.zcml:34
+msgid "SMS Authenticator Plone"
+msgstr ""
+
+#: ../configure.zcml:42
+msgid "SMS Authenticator Plone Action Uninstall"
+msgstr ""
+
+#: ../browser/controlpanel.py:138
 #: ../browser/helpers.py:12
 msgid "SMS Authenticator configuration"
 msgstr "SMS Authenticator configuratie"
@@ -335,19 +383,19 @@ msgstr "SMS Authenticator configuratie"
 msgid "SMS verification code"
 msgstr "SMS verificatie code"
 
-#: ../browser/controlpanel.py:136
+#: ../browser/controlpanel.py:182
 msgid "Save"
 msgstr "Opslaan"
 
-#: ../browser/controlpanel.py:83
+#: ../browser/controlpanel.py:108
 msgid "Secret Key"
 msgstr "Geheime Sleutel"
 
-#: ../userdataschema.py:81
+#: ../userdataschema.py:91
 msgid "Secret key"
 msgstr "Geheime Sleutel"
 
-#: ../browser/controlpanel.py:99
+#: ../browser/controlpanel.py:125
 msgid "Security"
 msgstr "Veiligheid"
 
@@ -377,6 +425,10 @@ msgstr "Toon unieke gebruiker IPs"
 msgid "Submit"
 msgstr "Verzenden"
 
+#: ../browser/controlpanel.py:54
+msgid "The SMS gateway provider"
+msgstr ""
+
 #: ../browser/forms/user_setup_mobile_number.py:44
 msgid ""
 "To setup two-step verification you need to enter your mobile phone numberto "
@@ -385,27 +437,27 @@ msgstr ""
 "Voor twee-stappen verificatie setup moet u uw mobiele telefoonnummer in te "
 "voeren waarop u wilt de SMS-berichten met inlogcodes ontvangen."
 
-#: ../browser/controlpanel.py:91
+#: ../browser/controlpanel.py:117
 msgid "Token lifetime"
 msgstr "Levensduur van token"
 
-#: ../userdataschema.py:87
+#: ../userdataschema.py:97
 msgid "Token to reset the mobile number"
 msgstr "Token om het mobiele nummer opnieuw in te stellen"
 
-#: ../browser/controlpanel.py:77
+#: ../browser/controlpanel.py:83
 msgid "Twilio"
 msgstr ""
 
-#: ../browser/controlpanel.py:62
+#: ../browser/controlpanel.py:68
 msgid "Twilio AccountSID"
 msgstr ""
 
-#: ../browser/controlpanel.py:69
+#: ../browser/controlpanel.py:75
 msgid "Twilio AuthToken"
 msgstr ""
 
-#: ../browser/controlpanel.py:55
+#: ../browser/controlpanel.py:61
 msgid "Twilio number"
 msgstr "Twilio nummer"
 
@@ -413,7 +465,7 @@ msgstr "Twilio nummer"
 msgid "Two-step verification"
 msgstr "Twee-stap verificatie"
 
-#: ../pas_plugin.py:130
+#: ../pas_plugin.py:138
 msgid ""
 "Two-step verification is enabled for your account, but you haven't specified "
 "a mobile number yet! In order to be able to log in, you have to go through "
@@ -427,13 +479,25 @@ msgstr ""
 msgid "Two-step verification is successfully enabled for your account."
 msgstr "De twee-stap verificatie is met succes ingeschakeld voor je account."
 
-#: ../browser/controlpanel.py:41
+#: ../browser/controlpanel.py:39
 msgid ""
 "Two-step verification will be ommit for users that log in from white listed "
 "addresses."
 msgstr ""
 "Twee-stappen verificatie zal worden zal worden weggelaten voor gebruikers "
 "die ingelogd zijn uit whitelist adressen."
+
+#: ../browser/controlpanel.py:46
+msgid "Two-step verification will be ommited for users in this list."
+msgstr ""
+
+#: ../configure.zcml:42
+msgid "Uninstall Postlogin Action"
+msgstr ""
+
+#: ../profiles.zcml:19
+msgid "Uninstalls the collective.smsauthenticator package"
+msgstr ""
 
 #: ../browser/templates/show_unique_user_ips.pt:19
 msgid "Unique user IPs"
@@ -444,15 +508,15 @@ msgid "Use the form below to (re)set your mobile phone number."
 msgstr ""
 "Gebruik het formulier hieronder om uw mobiele-nummer instellen/herstellen."
 
-#: ../helpers.py:524
+#: ../helpers.py:590
 msgid "Use this code to confirm your mobile phone reset: ${code}"
 msgstr ""
 
-#: ../helpers.py:546
+#: ../helpers.py:616
 msgid "Use this code to confirm your mobile phone setup: ${code}"
 msgstr ""
 
-#: ../helpers.py:535
+#: ../helpers.py:603
 msgid "Use this code to login: ${code}"
 msgstr ""
 
@@ -468,7 +532,7 @@ msgstr "Gebruiker niet gevonden {0}."
 msgid "Username"
 msgstr "Gebruikersnaam"
 
-#: ../userdataschema.py:76
+#: ../userdataschema.py:86
 msgid "Users' mobile number"
 msgstr "Mobiele nummer van gebruiker"
 
@@ -482,9 +546,13 @@ msgstr "Verifiëren"
 msgid "Welcome! You are now logged in."
 msgstr "Welkom! U bent nu aangemeld."
 
-#: ../browser/controlpanel.py:40
+#: ../browser/controlpanel.py:38
 msgid "White-listed IP addresses"
 msgstr "Witte lijst van IP-adressen"
+
+#: ../browser/controlpanel.py:45
+msgid "White-listed User id"
+msgstr ""
 
 #: ../browser/forms/reset_mobile_number.py:61
 msgid ""
@@ -535,8 +603,15 @@ msgstr ""
 msgid "Your SMS has just been resent."
 msgstr "Uw SMS is net opnieuw verzonden."
 
+#: ../profiles.zcml:11
+msgid "collective.smsauthenticator"
+msgstr ""
+
+#: ../profiles.zcml:19
+msgid "collective.smsauthenticator uninstall"
+msgstr ""
+
 #. Default: "Enter the login code sent to your mobile number\nIf you have somehow lost your mobile number, request a reset\n<a href='${absolute_url}/@@request-mobile-number-reset'>here</a>.\nIf you didn't receive an SMS message, resend it by clicking\nthe Resend SMS button below."
 #: ../browser/forms/token.py:208
 msgid "token_field_description"
 msgstr ""
-

--- a/src/collective/smsauthenticator/locales/update_locales.sh
+++ b/src/collective/smsauthenticator/locales/update_locales.sh
@@ -25,7 +25,7 @@ done
 
 # Assume i18ndude is installed with buildout
 # and this script is run under src/ folder with two nested namespaces in the package name (like mfabrik.plonezohointegration)
-I18NDUDE=i18ndude
+I18NDUDE=./i18ndude
 
 #
 # Do we need to merge manual PO entries from a file called manual.pot.


### PR DESCRIPTION
Messagebird support has been added by creating an extra tab for messagebird api key + sender name.
In the general tab of the controlpanel, admins can switch between Twilio and Messagebird.

This could be made more pluggable, but that is a considerable amount of extra work and requires quite some z3cform-foo.
